### PR TITLE
✨ feat: Align with stereosd and agentd flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770996920,
-        "narHash": "sha256-qH3o5teP6gtp7GWqdRicvm6hVrqCxPHvB7HWM6t+VUo=",
+        "lastModified": 1771336930,
+        "narHash": "sha256-2/FkSmAKpygbF2EfVUDR5ZvcD/9edesKPKO8BWpD00o=",
         "owner": "papercomputeco",
         "repo": "agentd",
-        "rev": "320d148c1b0e348c933611eadfd99dcfd4546748",
+        "rev": "d70ccb01865c69fc70aa29381eba23a74f683a0f",
         "type": "github"
       },
       "original": {
@@ -128,11 +128,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771100351,
-        "narHash": "sha256-KyfYlOnU1luctOiUl5DmekKXZQYpVfHzGYBGsSREHMo=",
+        "lastModified": 1771286433,
+        "narHash": "sha256-i8nJvSFqeAtHeafTuQLgejy2BxBWcSZlqNlF2Zz+jhA=",
         "owner": "papercomputeco",
         "repo": "stereosd",
-        "rev": "ec83bd91d211d65affa4ee0c64e8025ba674d1d1",
+        "rev": "72c68a9718d3dc087b848ed384da90e00c0f701c",
         "type": "github"
       },
       "original": {

--- a/stereos/modules/agent-user.nix
+++ b/stereos/modules/agent-user.nix
@@ -113,10 +113,15 @@ in
     # Register the custom shell so NixOS accepts it as a valid login shell
     environment.shells = [ "${agentShell}/bin/stereos-agent-shell" ];
 
+    # -- Admin group ---------------------------------------------------------
+    # The admin group controls access to stereosd/agentd sockets and tmux
+    # sessions.  Privilege hierarchy: root > admin > agent.
+    users.groups.admin = {};
+
     # -- Admin user (full access) --------------------------------------------
     users.users.admin = {
       isNormalUser = true;
-      extraGroups = [ "wheel" ];  # Grants sudo + nix daemon access
+      extraGroups = [ "wheel" "admin" ];  # wheel = sudo, admin = socket access
       openssh.authorizedKeys.keys = config.stereos.ssh.authorizedKeys;
     };
 

--- a/stereos/modules/base.nix
+++ b/stereos/modules/base.nix
@@ -96,6 +96,7 @@
     tree
     file
     unzip
+    ghostty.terminfo  # xterm-ghostty terminfo entry
   ];
 
   # -- Locale and timezone ---------------------------------------------------


### PR DESCRIPTION
* ✨ Aligns with upstream `agentd` flake: https://github.com/papercomputeco/agentd
* ✨ Aligns with upstream `stereosd` flake: https://github.com/papercomputeco/stereosd
* ✨ Sets up `admin` group with access to admin dirs
* ✨ Sets up `agent` group run dir