### PR TITLE
✨ feat: Optimize for qemu boot times

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,7 @@
 
         # StereOS base modules
         ./stereos/modules/base.nix
+        ./stereos/modules/boot-optimization.nix
         ./stereos/modules/agent-user.nix
         ./stereos/modules/image.nix
 
@@ -187,7 +188,18 @@
               value = qcow2Pkgs.${name};
             }) (builtins.attrNames qcow2Pkgs)
           );
+          # Kernel artifacts (bzImage + initrd + cmdline) for direct-kernel boot.
+          # Build with: nix build .#packages.aarch64-linux.<name>-kernel-artifacts
+          kernelArtifactPkgs = builtins.mapAttrs
+            (_name: cfg: cfg.config.system.build.kernelArtifacts)
+            configs;
+          kernelArtifactsNamed = builtins.listToAttrs (
+            builtins.map (name: {
+              name = "${name}-kernel-artifacts";
+              value = kernelArtifactPkgs.${name};
+            }) (builtins.attrNames kernelArtifactPkgs)
+          );
         in
-          rawPkgs // qcow2Named;
+          rawPkgs // qcow2Named // kernelArtifactsNamed;
     };
 }

--- a/stereos/modules/boot-optimization.nix
+++ b/stereos/modules/boot-optimization.nix
@@ -1,0 +1,174 @@
+# stereos/modules/boot-optimization.nix
+#
+# Boot time optimizations targeting sub-3-second boot for the stereOS
+# agent sandbox image when launched via QEMU (-M microvm) or Apple
+# Virtualization.framework.
+#
+# This module is split into two phases matching the SPEC:
+#
+#   Phase 1 — High-impact, low-effort
+#   Phase 2 — Medium effort (service audit, volatile journal, NSS)
+#
+# Verification: check /run/stereos-ready for a Unix nanosecond timestamp
+# written by the stereos-ready.service unit once multi-user.target is reached.
+
+{ config, lib, pkgs, ... }:
+
+{
+  # ============================================================
+  # Phase 1: High-Impact, Low-Effort
+  # ============================================================
+
+  # -- Boot infrastructure ---------------------------------------------------
+
+  # Systemd-based initrd: replaces NixOS's sequential bash stage-1 with a
+  # parallelized systemd initrd.  Expected savings: 1-3 s.
+  boot.initrd.systemd.enable = true;
+
+  # Silence kernel output — no printk spam on the serial console during boot.
+  boot.kernelParams = lib.mkMerge [
+    (lib.mkBefore [ "quiet" "loglevel=0" ])
+  ];
+  boot.consoleLogLevel = 0;
+
+  # Restrict initrd to only the kernel modules needed for virtio-backed VMs.
+  # This keeps the initrd small and avoids probing irrelevant hardware.
+  boot.initrd.availableKernelModules = lib.mkForce [
+    "virtio_blk"
+    "virtio_pci"
+    "virtio_net"
+    "virtio_console"
+    "virtiofs"
+    "ext4"
+    "erofs"
+    "overlay"
+  ];
+  # Nothing force-loaded at initrd time — let systemd-udevd handle it.
+  boot.initrd.kernelModules = lib.mkForce [];
+
+  # Use systemd-networkd for networking instead of scripted ifup.
+  # Pairs with disabling the wait-online stall below.
+  networking.useNetworkd = true;
+  networking.useDHCP = false;
+
+  # Configure systemd-networkd to DHCP on all ethernet interfaces.
+  # When useNetworkd=true and useDHCP=false, explicit .network units are
+  # required — without them, networkd ignores all interfaces and the guest
+  # has no IP address (breaking SSH, stereosd TCP, and all egress).
+  # QEMU's SLIRP stack provides a DHCP server at 10.0.2.2.
+  systemd.network.networks."10-ethernet" = {
+    matchConfig.Type = "ether";
+    networkConfig = {
+      DHCP = "yes";
+      # Don't wait for DHCP to finish before declaring the link "online".
+      # This avoids boot stalls if the DHCP server is slow or unavailable.
+      LinkLocalAddressing = "ipv4";
+    };
+    dhcpV4Config = {
+      # Accept the default route from QEMU SLIRP (10.0.2.2)
+      UseDomains = true;
+    };
+  };
+
+  # Do not stall boot waiting for all interfaces to become online.
+  # The host's SLIRP/vmnet interface comes up asynchronously; we don't need
+  # to block multi-user.target on it.
+  systemd.services.systemd-networkd-wait-online.enable = lib.mkForce false;
+
+  # -- Disable unnecessary NixOS defaults ------------------------------------
+
+  # Documentation generation adds significant closure size and build time;
+  # an ephemeral agent sandbox has no use for man pages or NixOS manuals.
+  documentation.enable = false;
+  documentation.man.enable = false;
+  documentation.nixos.enable = false;
+  documentation.info.enable = false;
+  documentation.doc.enable = false;
+
+  # Firewall: isolation is enforced at the VM boundary (the host controls
+  # what reaches the VM), not by iptables inside the guest.  Disabling
+  # netfilter removes the iptables/nftables rule-loading unit from the boot
+  # critical path.
+  networking.firewall.enable = lib.mkForce false;
+
+  # polkit is a desktop-policy daemon; stereOS is headless and has no GUI
+  # tooling that would use it.
+  security.polkit.enable = false;
+
+  # udisks2 auto-mounts removable media — irrelevant inside a VM with a
+  # single virtio block device.
+  services.udisks2.enable = false;
+
+  # XDG portals are desktop-portal bridges (Flatpak / Wayland); not needed
+  # in a headless agent environment.
+  xdg.portal.enable = false;
+
+  # command-not-found invokes nix-index on every unknown command, adding
+  # latency and requiring a channel database that we don't ship.
+  programs.command-not-found.enable = false;
+
+  # Disable nixos-rebuild / nix-channel infrastructure.  We use flakes;
+  # there is no channel to update and no reason for the channel cron job.
+  nix.channel.enable = false;
+
+  # Immutable user database: no passwd/shadow writes at boot, which removes
+  # the activation script step that re-generates those files.
+  users.mutableUsers = false;
+
+  # -- Systemd timeouts ------------------------------------------------------
+
+  # Tighten start/stop/device timeouts for the ephemeral sandbox use-case.
+  # Default NixOS values are 90 s (start) and 90 s (stop); these are far
+  # too long for a VM that should boot and shut down in under 5 s total.
+  systemd.settings.Manager = {
+    DefaultTimeoutStartSec = "10s";
+    DefaultTimeoutStopSec = "3s";
+    DefaultDeviceTimeoutSec = "3s";
+  };
+
+  # ============================================================
+  # Phase 2: Medium Effort
+  # ============================================================
+
+  # -- Service audit ---------------------------------------------------------
+
+  # stereOS is headless; there is no interactive login via a TTY or serial
+  # console.  Disabling getty removes several units from the boot graph.
+  services.getty.autologinUser = lib.mkForce null;
+  systemd.services."getty@".enable = lib.mkForce false;
+  systemd.services."serial-getty@".enable = lib.mkForce false;
+  systemd.services."autovt@".enable = lib.mkForce false;
+
+  # Use a volatile (in-memory) journal.  An ephemeral sandbox VM has no need
+  # for persistent logs across reboots, and avoiding disk writes reduces I/O
+  # on the boot critical path.
+  services.journald.storage = "volatile";
+  services.journald.extraConfig = ''
+    RuntimeMaxUse=32M
+  '';
+
+  # Restrict NSS to local files + DNS only.  Without this, glibc may try
+  # LDAP/mDNS/systemd-resolved lookups for passwd and group entries, adding
+  # latency to every getpwuid/getgrnam call that services make during startup.
+  system.nssDatabases.passwd = lib.mkForce [ "files" ];
+  system.nssDatabases.group  = lib.mkForce [ "files" ];
+  system.nssDatabases.hosts  = lib.mkForce [ "files" "dns" ];
+
+  # ============================================================
+  # Verification: boot complete marker
+  # ============================================================
+
+  # This oneshot unit writes a Unix nanosecond timestamp to /run/stereos-ready
+  # once multi-user.target (and stereosd.service) have been reached.
+  # Compare the value against the kernel boot timestamp in /proc/uptime to
+  # measure total time-to-ready.
+  systemd.services.stereos-ready = {
+    description = "StereOS boot complete marker";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "stereosd.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.coreutils}/bin/sh -c '${pkgs.coreutils}/bin/date +%s%N > /run/stereos-ready'";
+    };
+  };
+}

--- a/stereos/modules/image.nix
+++ b/stereos/modules/image.nix
@@ -2,18 +2,27 @@
 #
 # Produces bootable disk images for the current NixOS configuration.
 #
-# Two formats are available:
+# Formats available:
 #
-#   system.build.raw    — Raw disk image (canonical artifact).
-#                         Used by Apple Virtualization.framework
-#                         and as the base for OCI distribution.
+#   system.build.raw      — Raw disk image (canonical artifact).
+#                           Used by Apple Virtualization.framework
+#                           and as the base for OCI distribution.
 #
-#   system.build.qcow2  — QCOW2 image derived from the raw image.
-#                         Used by QEMU and KVM/libvirt backends.
+#   system.build.qcow2    — QCOW2 image derived from the raw image.
+#                           Used by QEMU and KVM/libvirt backends.
+#
+#   system.build.kernelArtifacts
+#                         — Directory containing the kernel (bzImage),
+#                           initrd, and a cmdline file for direct-kernel
+#                           boot via QEMU (-kernel/-initrd) or Apple
+#                           Virtualization.framework.  Enables bypassing
+#                           the UEFI/GRUB boot path entirely, which is
+#                           the primary mechanism for sub-3-second boot.
 #
 # Build with:
-#   nix build .#packages.aarch64-linux.<mixtape-name>         # → raw
-#   nix build .#packages.aarch64-linux.<mixtape-name>-qcow2   # → qcow2
+#   nix build .#packages.aarch64-linux.<mixtape-name>                  # → raw
+#   nix build .#packages.aarch64-linux.<mixtape-name>-qcow2            # → qcow2
+#   nix build .#packages.aarch64-linux.<mixtape-name>-kernel-artifacts # → kernel dir
 #
 
 { config, lib, pkgs, modulesPath, ... }:
@@ -51,5 +60,50 @@ in
     qemu-img convert -f raw -O qcow2 \
       ${config.system.build.raw}/nixos.img \
       $out/nixos.qcow2
+  '';
+
+  # -- Direct-kernel boot artifacts ------------------------------------------
+  #
+  # Collect the kernel image, initrd, and kernel command line into a single
+  # output directory.  These are used for direct-kernel boot — bypassing the
+  # UEFI/GRUB boot path — which is the most reliable path to sub-3-second
+  # total boot time.
+  #
+  # QEMU usage:
+  #   qemu-system-aarch64 \
+  #     -kernel result-kernel/bzImage \
+  #     -initrd result-kernel/initrd \
+  #     -append "$(cat result-kernel/cmdline)" \
+  #     ...
+  #
+  # Apple Virtualization.framework usage:
+  #   Set VZLinuxBootLoader.kernelURL / initialRamdiskURL / commandLine from
+  #   the corresponding files in this directory.
+  #
+  # Contents:
+  #   bzImage   — compressed kernel image
+  #   initrd    — initramfs (gzip-compressed cpio archive)
+  #   cmdline   — space-separated kernel parameters (one line, no trailing newline)
+  #   init      — path to the NixOS stage-2 init inside the Nix store
+  #
+  system.build.kernelArtifacts = pkgs.runCommand "${imageName}-kernel-artifacts" {} ''
+    mkdir -p $out
+
+    # Kernel image (bzImage / Image depending on architecture)
+    cp ${config.boot.kernelPackages.kernel}/${config.system.boot.loader.kernelFile} \
+       $out/bzImage
+
+    # Initrd — the .gz file produced by NixOS
+    cp ${config.system.build.initialRamdisk}/initrd \
+       $out/initrd
+
+    # Kernel command line: join the list with spaces, strip trailing newline.
+    # We append "init=<toplevel>/init" so the kernel hands off to NixOS
+    # stage-2 directly (required for direct-kernel boot without a bootloader).
+    printf '%s' "${lib.concatStringsSep " " config.boot.kernelParams} init=${config.system.build.toplevel}/init" \
+      > $out/cmdline
+
+    # Convenience symlink: the NixOS stage-2 init path
+    echo "${config.system.build.toplevel}/init" > $out/init
   '';
 }


### PR DESCRIPTION
* ✨ Exports kernel + initrd + cmdline as build artifacts for direct kernel boot
* ✨ Enables systemd in initrd
* ✨ Silences kernel outputs / bootlog level = 0
* ✨ Restricts initrd to virtio modules
* ✨ Uses systemd-networkd
* ✨ Doesn't generate NixOS docs (i.e. `documentation.enable = false`)
* ✨ Disable nix channels / nixos-rebuilds: might want to bring this back latter for `switch` to new image versions
* ✨ Abunch of other config changes that probably aren't as meaningful or impactful

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox/pr/papercomputeco/stereOS/2?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->