### PR TITLE
🧹 chore: remove default injected dev ssh key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ stereos/
 │   └── kernel-artifacts.nix        # Direct-kernel boot (bzImage + initrd + cmdline)
 │
 ├── lib/                            # Shared Nix helper functions
-│   └── default.nix                 # mkMixtape helper, SSH key logic
+│   └── default.nix                 # mkMixtape helper
 │
 ├── scripts/
 │   └── run-vm.sh                   # QEMU VM launcher

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Based around the auto-documented Makefile:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
-MIXTAPE  ?= opencode-mixtape
+MIXTAPE  ?= opencode-mixtape-dev
 ARCH     ?= aarch64-linux
 SSH_PORT ?= 2222
 

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,12 @@
         };
 
         # System configurations ("mixtapes")
+        #
+        # Default configurations are production-ready (no SSH keys baked in).
+        # Dev configurations (*-dev) include profiles/dev.nix which injects
+        # the developer's SSH key from ~/.config/stereos/ssh-key.pub.
         nixosConfigurations = {
+          # -- Production configurations --------------------------------------
           opencode-mixtape = stereos-lib.mkMixtape {
             name = "opencode-mixtape";
             features = [ ./mixtapes/opencode/base.nix ];
@@ -65,6 +70,31 @@
           full-mixtape = stereos-lib.mkMixtape {
             name = "full-mixtape";
             features = [ ./mixtapes/full/base.nix ];
+          };
+
+          # -- Dev configurations (SSH key injection) --------------------------
+          opencode-mixtape-dev = stereos-lib.mkMixtape {
+            name = "opencode-mixtape";
+            features = [ ./mixtapes/opencode/base.nix ];
+            extraModules = [ ./profiles/dev.nix ];
+          };
+
+          claude-code-mixtape-dev = stereos-lib.mkMixtape {
+            name = "claude-code-mixtape";
+            features = [ ./mixtapes/claude-code/base.nix ];
+            extraModules = [ ./profiles/dev.nix ];
+          };
+
+          gemini-cli-mixtape-dev = stereos-lib.mkMixtape {
+            name = "gemini-cli-mixtape";
+            features = [ ./mixtapes/gemini-cli/base.nix ];
+            extraModules = [ ./profiles/dev.nix ];
+          };
+
+          full-mixtape-dev = stereos-lib.mkMixtape {
+            name = "full-mixtape";
+            features = [ ./mixtapes/full/base.nix ];
+            extraModules = [ ./profiles/dev.nix ];
           };
         };
       };

--- a/profiles/dev.nix
+++ b/profiles/dev.nix
@@ -13,12 +13,25 @@
 # Setup:
 #   mkdir -p ~/.config/stereos
 #   cp ~/.ssh/id_ed25519.pub ~/.config/stereos/ssh-key.pub
+#
+# Usage:
+#   Include this profile in mkMixtape's extraModules for dev builds.
+#   Production builds should NOT include this profile.
 
 { config, lib, pkgs, ... }:
 
+let
+  sshKeyPath = builtins.getEnv "HOME" + "/.config/stereos/ssh-key.pub";
+  sshKeys =
+    let
+      exists = builtins.pathExists sshKeyPath;
+    in
+      if exists then
+        let raw = builtins.readFile sshKeyPath;
+        in [ (lib.removeSuffix "\n" raw) ]
+      else
+        [];
+in
 {
-  # The SSH key injection is handled in lib/default.nix (mkMixtape)
-  # which sets stereos.ssh.authorizedKeys. This profile exists as
-  # the canonical place to add dev-only configuration in the future
-  # (e.g., debug tools, verbose logging, etc.)
+  stereos.ssh.authorizedKeys = sshKeys;
 }


### PR DESCRIPTION
* 🧹 remove default ssh key that gets injected. This is handled by `stereosd`