### PR TITLE
✨ feat: gVisor + /nix/store sandboxes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771965841,
-        "narHash": "sha256-p4izQJPfb7hZTnm+b3n8GqAFhn7EA8MdCuEdWbX4pNM=",
+        "lastModified": 1772303427,
+        "narHash": "sha256-/neRArqcKv9BbugyBztkZbiuMYL0ATpwVUSf1iYFdQM=",
         "owner": "papercomputeco",
         "repo": "agentd",
-        "rev": "b03e4087586f478adf0a7885e1010741acf4bd07",
+        "rev": "f1a6c65d32a6141d2eedf6e89c6385c8ca5cd407",
         "type": "github"
       },
       "original": {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,7 +4,44 @@
 
 { inputs }:
 
-{
+rec {
+  # -- mkSandboxManifest -----------------------------------------------------
+  #
+  # Returns a NixOS module that pre-computes the Nix store closure for the
+  # gVisor sandbox profile at build time. The closure manifest is installed
+  # to /etc/stereos/sandbox-closure.txt, which agentd reads as the fast path
+  # when it boots up sandboxes (instead of running `nix-store -qR` at runtime).
+  #
+  # The manifest includes the base agent packages (the same curated set
+  # from the agent user) plus whatever config.stereos.agent.extraPackages the
+  # mixtape injects. mkMixtape auto-includes this module, so every
+  # mixtape gets a manifest that is specific to its own package set.
+  mkSandboxManifest =
+    { }:
+    { config, lib, pkgs, ... }:
+    let
+      # Combine base agent package options with mixtape package options.
+      allPackages = config.stereos.agent.basePackages
+        ++ config.stereos.agent.extraPackages;
+
+      # Build a single environment from all packages.
+      sandboxProfile = pkgs.buildEnv {
+        name = "stereos-sandbox-profile";
+        paths = allPackages;
+        pathsToLink = [ "/bin" "/lib" "/share" "/etc" ];
+      };
+
+      # Use closureInfo to compute the full /nix/store closure at build time.
+      closureManifest = pkgs.closureInfo { rootPaths = [ sandboxProfile ]; };
+    in
+    {
+      # Install the closure manifest to a well-known path that agentd reads.
+      environment.etc."stereos/sandbox-closure.txt" = {
+        source = "${closureManifest}/store-paths";
+        mode = "0444";
+      };
+    };
+
   # -- mkMixtape -------------------------------------------------------------
   #
   # Build a complete NixOS system configuration ("mixtape") from:
@@ -12,6 +49,7 @@
   #   - A profile (profiles/base.nix)
   #   - External flake modules (agentd, stereosd) + overlays
   #   - Mixtape-specific feature modules
+  #   - The sandbox closure manifest (auto-included)
   #
   # For dev builds, include profiles/dev.nix via extraModules to get
   # SSH key injection and debug tooling.  Production builds should NOT
@@ -46,6 +84,9 @@
 
         # Shared base profile
         ../profiles/base.nix
+
+        # Pre-computed sandbox closure manifest (per-mixtape)
+        (mkSandboxManifest { })
 
         # Mixtape identity
         {

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -88,6 +88,7 @@
     file
     unzip
     ghostty.terminfo  # xterm-ghostty terminfo entry
+    gvisor            # runsc: gVisor sandbox runtime for sandboxed agents
   ];
 
   # -- Locale and timezone ---------------------------------------------------

--- a/modules/users/agent.nix
+++ b/modules/users/agent.nix
@@ -15,49 +15,10 @@
 { config, lib, pkgs, ... }:
 
 let
-  # -- Curated set of binaries the agent can access -------------------------
-  # This is the ONLY thing on the agent's PATH.
-  # Add packages here as needed — but never add nix tools.
-  agentPackages = with pkgs; [
-    # Core POSIX utilities
-    coreutils
-    gnugrep
-    gnused
-    gawk
-    findutils
-    diffutils
-    less
-    which
-
-    # Development essentials
-    git
-    curl
-    jq
-    ripgrep
-    tree
-    file
-    unzip
-    gnumake
-
-    # Editors
-    vim
-
-    # Terminal multiplexer
-    tmux
-
-    # Process inspection (safe subset)
-    htop
-    procps  # ps, top, etc.
-
-    # Networking
-    openssh  # ssh client for agent-to-agent or git-over-ssh
-    cacert   # TLS certificates
-  ];
-
   # Build a single directory containing symlinks to all approved binaries
   agentEnv = pkgs.buildEnv {
     name = "stereos-agent-env";
-    paths = agentPackages;
+    paths = config.stereos.agent.basePackages;
     pathsToLink = [ "/bin" "/lib" "/share" "/etc" ];
   };
 
@@ -99,6 +60,53 @@ in
       type = lib.types.listOf lib.types.str;
       default = [];
       description = "SSH public keys authorized for both admin and agent users.";
+    };
+
+    agent.basePackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      description = ''
+        Curated set of packages available on the agent's PATH and in the
+        gVisor sandbox closure.  Override to add or remove base tools;
+        use stereos.agent.extraPackages for mixtape-specific additions.
+      '';
+      default = with pkgs; [
+        # Core POSIX utilities
+        coreutils
+        gnugrep
+        gnused
+        gawk
+        findutils
+        diffutils
+        less
+        which
+
+        # Development essentials
+        git
+        curl
+        jq
+        ripgrep
+        tree
+        file
+        unzip
+        gnumake
+
+        # Editors
+        vim
+
+        # Terminal multiplexer
+        tmux
+
+        # Process inspection (safe subset)
+        htop
+        procps  # ps, top, etc.
+
+        # Networking
+        openssh  # ssh client for agent-to-agent or git-over-ssh
+        cacert   # TLS certificates
+
+        # Shell (needed as the sandbox entrypoint)
+        bash
+      ];
     };
 
     agent.extraPackages = lib.mkOption {


### PR DESCRIPTION
* 🧹 Upgrades `agentd` to consume gVisor support: https://github.com/papercomputeco/agentd/pull/8
* ✨ new `mkSandboxManifest` that computes `/nix/store` closures at build time: the closure can then be referenced by `agentd` in order to build gVisor OCI sandboxes with linked paths to the nix store.
* 🧹 moves the agent user packages in to an option under `agent.basePackages`

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox/pr/papercomputeco/stereOS/15?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->