### PR TITLE
✨ feat: fix stereOS ready

### DIFF
--- a/modules/boot.nix
+++ b/modules/boot.nix
@@ -209,7 +209,7 @@
     after = [ "stereosd.service" ];
     serviceConfig = {
       Type = "oneshot";
-      ExecStart = "${pkgs.coreutils}/bin/sh -c '${pkgs.coreutils}/bin/date +%s%N > /run/stereos-ready'";
+      ExecStart = "${pkgs.bash}/bin/sh -c '${pkgs.coreutils}/bin/date > /run/stereos-ready'";
     };
   };
 }


### PR DESCRIPTION
* ✨ fixes issue where `sh` isn't in coreutils causing the stereos ready service to report error

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox/pr/papercomputeco/stereOS/16?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->