### PR TITLE
✨ feat: Introduce "VERSIONING.md" for aligning on versioning the OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,5 +87,5 @@ stereOS declares two custom options:
 |-------------|-----------|----------|
 | `agentd` | `github:papercomputeco/agentd` | `services.agentd` NixOS module + overlay |
 | `stereosd` | `github:papercomputeco/stereosd` | `services.stereosd` NixOS module + overlay |
-| `nixpkgs` | `nixpkgs-unstable` | Base packages |
+| `nixpkgs` | `nixos-25.11` | Base packages |
 | `dagger` | `github:dagger/nix` | CI engine |

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,52 @@
+# stereOS Versioning
+
+stereOS uses unified [calendar versioning (CalVer)](https://calver.org/)
+with mixtape specific OCI registry streams.
+
+All mixtapes share a common base (the `modules/`, `lib/`, `profiles/`, etc.)
+and share one version derived from a git tag.
+Each mixtape carries their own individual packages and features specific to a use case.
+Each mixtape gets rebuilt on each tag in order to align on the common base.
+
+## Format
+
+```
+YYYY.0M.DD.N
+```
+
+- **YYYY** — four-digit year
+- **0M** — zero-padded monthly
+- **0D** - zero-padded day
+- **N** — release counter for that day, starting at 0
+
+Examples: `2026.03.01.0`, `2077.11.21.9`, `2030.01.01.100`
+
+To see exactly what changed between two releases, compare the commit tags:
+
+```bash
+git log 2026.03.1.0..2026.03.1.99
+```
+
+## OCI mixtape format
+
+Individual mixtape images are available in the `download.stereos.ai/mixtapes` OCI registry.
+Each mixtape gets its own channel with a few utility tags available:
+
+```
+download.stereos.ai/mixtapes/coder:latest
+download.stereos.ai/mixtapes/coder:nightly
+download.stereos.ai/mixtapes/coder:2026.03.01.0
+```
+
+* `latest` always points to the most recent tagged release.
+* `nightly` are unstable nightly builds. CI/CD selectively builds nightly releases
+based on what's changed for a mixtape's packages, modules, profiles, etc.
+Use at your own risk.
+
+## Upstream NixOS
+
+stereOS core system components follows stable NixOS releases. These update every 6 months
+(typically at the end of May and November).
+
+Other non-system-critical packages (like coding agents) follow nixpkgs-unstable.
+These are much more frequently updated.

--- a/flake.lock
+++ b/flake.lock
@@ -118,16 +118,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771207753,
-        "narHash": "sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE=",
+        "lastModified": 1772047000,
+        "narHash": "sha256-7DaQVv4R97cii/Qdfy4tmDZMB2xxtyIvNGSwXBBhSmo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d1c15b7d5806069da59e819999d70e1cec0760bf",
+        "rev": "1267bb4920d0fc06ea916734c11b0bf004bbe17e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -147,12 +147,29 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1772419343,
+        "narHash": "sha256-QU3Cd5DJH7dHyMnGEFfPcZDaCAsJQ6tUD+JuUsYqnKU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "93178f6a00c22fcdee1c6f5f9ab92f2072072ea9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "agentd": "agentd",
         "dagger": "dagger",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "stereosd": "stereosd"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,8 @@
   description = "stereOS — a NixOS-based operating system for AI agents";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     dagger.url = "github:dagger/nix";
     dagger.inputs.nixpkgs.follows = "nixpkgs";
@@ -18,9 +19,9 @@
     };
   };
 
-  outputs = inputs@{ flake-parts, ... }:
+  outputs = inputs@{ self, flake-parts, ... }:
     let
-      stereos-lib = import ./lib { inherit inputs; };
+      stereos-lib = import ./lib { inherit inputs self; };
     in
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [

--- a/flake/images.nix
+++ b/flake/images.nix
@@ -18,6 +18,7 @@
 
 let
   stereos-lib = import ../lib/dist.nix { inherit inputs; };
+  stereos-main = import ../lib { inherit inputs self; };
   system = "aarch64-linux";
   pkgs = inputs.nixpkgs.legacyPackages.${system};
 in
@@ -64,10 +65,11 @@ in
             name = "${name}-dist";
             value = stereos-lib.mkDist {
               inherit pkgs system;
-              name   = name;
-              raw    = rawPkgs.${name};
-              qcow2  = qcow2Pkgs.${name};
-              kernel = kernelArtifactPkgs.${name};
+              name    = name;
+              version = stereos-main.stereosVersion;
+              raw     = rawPkgs.${name};
+              qcow2   = qcow2Pkgs.${name};
+              kernel  = kernelArtifactPkgs.${name};
             };
           }) mixtapeNames
         );

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -2,9 +2,41 @@
 #
 # Shared Nix helper functions for stereOS.
 
-{ inputs }:
+{ inputs, self }:
+
+let
+  # -- stereOS version -------------------------------------------------------
+  #
+  # CI sets STEREOS_VERSION to the git tag (e.g. "2026.03.01.0") before
+  # building with --impure.  Local dev builds fall back to a commit-based
+  # string so every image always carries *some* identity.
+  #
+  # Resolution order:
+  #   1. $STEREOS_VERSION env var     (CI — requires --impure)
+  #   2. "dev-<shortRev>"             (clean git worktree)
+  #   3. "dev-<dirtyShortRev>"        (dirty git worktree)
+  #   4. "dev-<lastModifiedDate>"     (path: input with no git context)
+  #
+  # Note: when consuming stereOS via --override-input, prefer
+  # "git+file:" over "path:" to preserve git revision metadata.
+  #
+  envVersion = builtins.getEnv "STEREOS_VERSION";
+
+  stereosVersion =
+    if envVersion != "" then envVersion
+    else if self ? shortRev then "dev-${self.shortRev}"
+    else if self ? dirtyShortRev then "dev-${self.dirtyShortRev}"
+    else "dev-${self.lastModifiedDate or "unknown"}";
+
+  # Git revision for system.configurationRevision
+  gitRevision = self.rev or self.dirtyRev or "unknown";
+in
 
 rec {
+  # Expose the computed version so other flake modules can use it
+  # (e.g. flake/images.nix passes it to mkDist for mixtape.toml).
+  inherit stereosVersion;
+
   # -- mkSandboxManifest -----------------------------------------------------
   #
   # Returns a NixOS module that pre-computes the Nix store closure for the
@@ -65,6 +97,13 @@ rec {
   mkMixtape = { name, features ? [], system ? "aarch64-linux", extraModules ? [] }:
     inputs.nixpkgs.lib.nixosSystem {
       inherit system;
+      specialArgs = {
+        inherit stereosVersion gitRevision;
+        pkgs-unstable = import inputs.nixpkgs-unstable {
+          inherit system;
+          config.allowUnfree = true;
+        };
+      };
       modules = [
         # External flake NixOS modules -- provide services.agentd and
         # services.stereosd options + baseline systemd units.

--- a/mixtapes/coder/package.nix
+++ b/mixtapes/coder/package.nix
@@ -11,7 +11,7 @@
 # Required environment variables at runtime (depending on provider):
 #   ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY / GOOGLE_API_KEY
 
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, pkgs-unstable, ... }:
 
 {
   # Allow unfree packages required by this mixtape
@@ -20,20 +20,20 @@
       "claude-code"
     ];
 
-  # Add all coding agents to the agent's restricted PATH
+  # Add all coding agents to the agent's restricted PATH (from unstable)
   stereos.agent.extraPackages = [
-    pkgs.claude-code
-    pkgs.codex
-    pkgs.gemini-cli
-    pkgs.opencode
+    pkgs-unstable.claude-code
+    pkgs-unstable.codex
+    pkgs-unstable.gemini-cli
+    pkgs-unstable.opencode
   ];
 
   # Also make them available system-wide (for admin use)
   environment.systemPackages = [
-    pkgs.claude-code
-    pkgs.codex
-    pkgs.gemini-cli
-    pkgs.opencode
+    pkgs-unstable.claude-code
+    pkgs-unstable.codex
+    pkgs-unstable.gemini-cli
+    pkgs-unstable.opencode
   ];
 
   # Claude Code: disable auto-updater (belt-and-suspenders; Nix package sets this too)

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -5,7 +5,7 @@
 #
 # Boot configuration lives in boot.nix.
 
-{ config, lib, pkgs, modulesPath, ... }:
+{ config, lib, pkgs, modulesPath, stereosVersion, gitRevision, ... }:
 
 {
   imports = [
@@ -16,19 +16,29 @@
   # NixOS system version to track
   system.stateVersion = "24.11";
 
+  # -- stereOS version identity ----------------------------------------------
+  # Label shown by `nixos-version` and in boot entries.
+  # e.g. "stereOS-2026.03.01.0-coder" or "stereOS-dev-abc1234-coder"
+  system.nixos.label = "stereOS-${stereosVersion}-${config.networking.hostName}";
+
+  # Exact git commit — shows up in `nixos-version --json`.
+  system.configurationRevision = gitRevision;
+
   # -- stereOS system identity -----------------------------------------------
   # Override /etc/os-release so tools like hostnamectl show stereOS
   environment.etc."os-release".text = lib.mkForce ''
     NAME="stereOS"
     ID=stereos
     ID_LIKE=nixos
-    VERSION="${config.system.nixos.version}"
-    VERSION_ID="${config.system.nixos.version}"
-    PRETTY_NAME="stereOS (${config.networking.hostName})"
-    HOME_URL="https://github.com/paper-compute-co"
+    VERSION="${stereosVersion}"
+    VERSION_ID="${stereosVersion}"
+    VERSION_CODENAME="${config.networking.hostName}"
+    PRETTY_NAME="stereOS ${stereosVersion} (${config.networking.hostName})"
+    HOME_URL="https://github.com/papercomputeco/stereOS"
+    NIXOS_VERSION="${config.system.nixos.version}"
   '';
 
-  # "Sub- Zero" ASCII art stereOS logo for ssh splash
+  # "Sub-Zero" ASCII art stereOS logo for ssh splash
   users.motd = ''
   ______   ______  ______   ______   ______   ______   ______
  /\  ___\ /\__  _\/\  ___\ /\  == \ /\  ___\ /\  __ \ /\  ___\
@@ -36,6 +46,7 @@
   \/\_____\  \ \_\ \ \_____\\ \_\ \_\\ \_____\\ \_____\\/\_____\
    \/_____/   \/_/  \/_____/ \/_/ /_/ \/_____/ \/_____/ \/_____/
 
+    stereOS ${stereosVersion}
     Mixtape: ${config.networking.hostName}
 
   '';


### PR DESCRIPTION
* ✨ adds ability to read git rev version for builds
* 📚 adds `VERSIONING.md` to align on versioning the OS.

TLDR: uses CalVer and specific mixtape channels in the OCI registry.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox/pr/papercomputeco/stereOS/22?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->