### PR TITLE
✨ feat: Adds x86 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,26 +4,36 @@
 # Based around the auto-documented Makefile:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
+# -- Image builds ------------------------------------------------------------
+#
+# The "ARCH" env var must be specified for image builds.
+
 MIXTAPE  ?= coder
-ARCH     ?= aarch64-linux
+ARCH     ?=
 SSH_PORT ?= 2222
 
-# -- Image builds ------------------------------------------------------------
+define require-arch
+	$(if $(ARCH),,$(error ARCH is required. Use ARCH=aarch64-linux or ARCH=x86_64-linux))
+endef
 
 .PHONY: dist
 dist: ## Build all formats and assemble dist/ for publishing
+	$(call require-arch)
 	nix build .#packages.$(ARCH).$(MIXTAPE)-dist --impure
 
 .PHONY: build
 build: ## Build the default base mixtape (raw image)
+	$(call require-arch)
 	nix build .#packages.$(ARCH).$(MIXTAPE) --impure
 
 .PHONY: build-qcow2
 build-qcow2: ## Build the default mixtape (qcow2 image)
+	$(call require-arch)
 	nix build .#packages.$(ARCH).$(MIXTAPE)-qcow2 --impure
 
 .PHONY: build-kernel
 build-kernel: ## Build kernel artifacts for kernel boot
+	$(call require-arch)
 	nix build .#packages.$(ARCH).$(MIXTAPE)-kernel-artifacts --impure
 
 # -- VM development operations ------------------------------------------------

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,10 @@
         # Default configurations are production-ready (no SSH keys baked in).
         # Dev configurations (*-dev) include profiles/dev.nix which injects
         # the developer's SSH key from ~/.config/stereos/ssh-key.pub.
+        #
+        # These host-native configurations are intended for `nixos-rebuild` use.
+        # For image builds (packages.<system>.<name>), see flake/images.nix
+        # which generates per-system configurations for all target architectures.
         nixosConfigurations = {
           # -- Production configurations --------------------------------------
           base = stereos-lib.mkMixtape {

--- a/flake/devshell.nix
+++ b/flake/devshell.nix
@@ -28,8 +28,17 @@
 
         echo "stereOS dev shell"
         echo "  Go:   $(go version)"
-        echo "  QEMU: $(qemu-system-aarch64 --version | head -1)"
-        export STEREOS_EFI_CODE="${pkgs.qemu}/share/qemu/edk2-aarch64-code.fd"
+
+        # Set architecture-specific QEMU and EFI firmware
+        if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
+          echo "  QEMU: $(qemu-system-aarch64 --version | head 1)"
+          export QEMU_SYSTEM="qemu-system-aarch64"
+          export STEREOS_EFI_CODE="${pkgs.qemu}/share/qemu/edk2-aarch64-code.fd"
+        else
+          echo "  QEMU: $(qemu-system-x86_64 --version | head 1)"
+          export QEMU_SYSTEM="qemu-system-x86_64"
+          export STEREOS_EFI_CODE="${pkgs.qemu}/share/qemu/edk2-x86_64-code.fd"
+        fi
       '';
     };
   };

--- a/flake/images.nix
+++ b/flake/images.nix
@@ -1,79 +1,105 @@
 # flake/images.nix
 #
-# Per-system: Image build targets.
+# Per-system image build targets.
 #
-# Generates packages from nixosConfigurations:
+# Generates packages for each target architecture by constructing
+# system-specific nixosConfigurations via mkMixtape:
 #   packages.<system>.<mixtape-name>                    (raw)
 #   packages.<system>.<mixtape-name>-qcow2              (qcow2)
 #   packages.<system>.<mixtape-name>-kernel-artifacts   (direct-kernel boot)
 #   packages.<system>.<mixtape-name>-dist               (all formats + mixtape.toml)
 #
 # Build with:
-#   nix build .#packages.aarch64-linux.opencode-mixtape --impure
-#   nix build .#packages.aarch64-linux.opencode-mixtape-qcow2 --impure
-#   nix build .#packages.aarch64-linux.opencode-mixtape-kernel-artifacts --impure
-#   nix build .#packages.aarch64-linux.opencode-mixtape-dist --impure
+#   nix build .#packages.aarch64-linux.coder --impure
+#   nix build .#packages.x86_64-linux.coder --impure
 
 { self, inputs, ... }:
 
 let
   stereos-lib = import ../lib/dist.nix { inherit inputs; };
   stereos-main = import ../lib { inherit inputs self; };
-  system = "aarch64-linux";
-  pkgs = inputs.nixpkgs.legacyPackages.${system};
+
+  # Target architectures to build images for
+  targetSystems = [ "aarch64-linux" "x86_64-linux" ];
+
+  # Mixtape definitions — name + feature modules.
+  # Each entry produces a full set of image packages per target system.
+  # Dev variants include profiles/dev.nix for SSH key injection.
+  mixtapeSpecs = [
+    { name = "base";      features = [ ../mixtapes/base/package.nix ];  extraModules = []; }
+    { name = "coder";     features = [ ../mixtapes/coder/package.nix ]; extraModules = []; }
+    { name = "base-dev";  features = [ ../mixtapes/base/package.nix ];  extraModules = [ ../profiles/dev.nix ]; }
+    { name = "coder-dev"; features = [ ../mixtapes/coder/package.nix ]; extraModules = [ ../profiles/dev.nix ]; }
+  ];
+
+  # Helper to build packages for a given system
+  buildSystemImages = system:
+    let
+      pkgs = inputs.nixpkgs.legacyPackages.${system};
+
+      # Build a nixosConfiguration for each mixtape spec, targeting this system.
+      configs = builtins.listToAttrs (
+        builtins.map (spec: {
+          name = spec.name;
+          value = stereos-main.mkMixtape {
+            inherit system;
+            inherit (spec) name features extraModules;
+          };
+        }) mixtapeSpecs
+      );
+      mixtapeNames = builtins.attrNames configs;
+
+      # Raw images — canonical artifact
+      rawPkgs = builtins.mapAttrs
+        (_name: cfg: cfg.config.system.build.raw)
+        configs;
+      # QCOW2 images — derived from raw, for QEMU/KVM
+      qcow2Pkgs = builtins.mapAttrs
+        (_name: cfg: cfg.config.system.build.qcow2)
+        configs;
+      # Suffix qcow2 package names with "-qcow2"
+      qcow2Named = builtins.listToAttrs (
+        builtins.map (name: {
+          name = "${name}-qcow2";
+          value = qcow2Pkgs.${name};
+        }) mixtapeNames
+      );
+      # Kernel artifacts (bzImage + initrd + cmdline) for direct-kernel boot.
+      kernelArtifactPkgs = builtins.mapAttrs
+        (_name: cfg: cfg.config.system.build.kernelArtifacts)
+        configs;
+      kernelArtifactsNamed = builtins.listToAttrs (
+        builtins.map (name: {
+          name = "${name}-kernel-artifacts";
+          value = kernelArtifactPkgs.${name};
+        }) mixtapeNames
+      );
+      # Dist directories — all formats assembled into a single output.
+      distPkgs = builtins.listToAttrs (
+        builtins.map (name: {
+          name = "${name}-dist";
+          value = stereos-lib.mkDist {
+            inherit pkgs system;
+            name    = name;
+            version = stereos-main.stereosVersion;
+            raw     = rawPkgs.${name};
+            qcow2   = qcow2Pkgs.${name};
+            kernel  = kernelArtifactPkgs.${name};
+          };
+        }) mixtapeNames
+      );
+    in
+      rawPkgs // qcow2Named // kernelArtifactsNamed // distPkgs;
+
+  # Build packages for all target systems
+  allPackages = builtins.listToAttrs (
+    builtins.map (system: {
+      name = system;
+      value = buildSystemImages system;
+    }) targetSystems
+  );
 in
 {
-  # Image packages are not per-system in the flake-parts sense — they are
-  # always built for the target architecture (aarch64-linux).  We expose
-  # them via the top-level `flake` attrset.
-  flake = {
-    packages.aarch64-linux =
-      let
-        configs = self.nixosConfigurations;
-        mixtapeNames = builtins.attrNames configs;
-
-        # Raw images — canonical artifact
-        rawPkgs = builtins.mapAttrs
-          (_name: cfg: cfg.config.system.build.raw)
-          configs;
-        # QCOW2 images — derived from raw, for QEMU/KVM
-        qcow2Pkgs = builtins.mapAttrs
-          (_name: cfg: cfg.config.system.build.qcow2)
-          configs;
-        # Suffix qcow2 package names with "-qcow2"
-        qcow2Named = builtins.listToAttrs (
-          builtins.map (name: {
-            name = "${name}-qcow2";
-            value = qcow2Pkgs.${name};
-          }) mixtapeNames
-        );
-        # Kernel artifacts (bzImage + initrd + cmdline) for direct-kernel boot.
-        # Build with: nix build .#packages.aarch64-linux.<name>-kernel-artifacts
-        kernelArtifactPkgs = builtins.mapAttrs
-          (_name: cfg: cfg.config.system.build.kernelArtifacts)
-          configs;
-        kernelArtifactsNamed = builtins.listToAttrs (
-          builtins.map (name: {
-            name = "${name}-kernel-artifacts";
-            value = kernelArtifactPkgs.${name};
-          }) mixtapeNames
-        );
-        # Dist directories — all formats assembled into a single output.
-        # Build with: nix build .#packages.aarch64-linux.<name>-dist
-        distPkgs = builtins.listToAttrs (
-          builtins.map (name: {
-            name = "${name}-dist";
-            value = stereos-lib.mkDist {
-              inherit pkgs system;
-              name    = name;
-              version = stereos-main.stereosVersion;
-              raw     = rawPkgs.${name};
-              qcow2   = qcow2Pkgs.${name};
-              kernel  = kernelArtifactPkgs.${name};
-            };
-          }) mixtapeNames
-        );
-      in
-        rawPkgs // qcow2Named // kernelArtifactsNamed // distPkgs;
-  };
+  # Image packages are per-system — they are built for the target architecture.
+  flake.packages = allPackages;
 }

--- a/modules/boot.nix
+++ b/modules/boot.nix
@@ -2,8 +2,6 @@
 #
 # Boot configuration and boot-time optimizations for stereOS.
 #
-# aarch64 requires UEFI boot — there is no BIOS on ARM.
-#
 # Boot optimizations target sub-3-second boot for the stereOS agent
 # sandbox image when launched via QEMU (-M microvm) or Apple
 # Virtualization.framework.
@@ -18,10 +16,14 @@
 
 { config, lib, pkgs, ... }:
 
+let
+  isAarch64 = pkgs.system == "aarch64-linux";
+in
 {
   # -- Boot ------------------------------------------------------------------
-  # efiInstallAsRemovable puts GRUB at /EFI/BOOT/BOOTAA64.EFI,
-  # which is the fallback path QEMU's UEFI firmware searches.
+  # efiInstallAsRemovable=true puts GRUB at /EFI/BOOT/BOOTAA64.EFI (aarch64)
+  # or /EFI/BOOT/BOOTX64.EFI (x86_64), which is the fallback path
+  # QEMU's UEFI firmware searches. The correct filename is determined by grub-install.
   boot.loader.grub = {
     enable = true;
     efiSupport = true;
@@ -34,15 +36,21 @@
   # of them, but only the *last* one becomes /dev/console (used by init and
   # systemd for stdin/stdout). We list the primary console last.
   #
+  # aarch64:
   #   ttyAMA0  — PL011 UART on QEMU's virt machine (aarch64 -serial)
   #   hvc0     — virtio console on Apple Virtualization.framework
   #   tty0     — virtual terminal (active when a display is attached)
   #
-  # With this ordering, hvc0 is /dev/console. QEMU's -serial still captures
-  # ttyAMA0 output. Apple Virt's VirtioConsoleDevice captures hvc0.
+  # x86_64:
+  #   ttyS0    — COM1 serial port on QEMU standard PC
+  #   tty0     — virtual terminal
+  #
+  # With this ordering, hvc0/ttyS0 is /dev/console.
   boot.kernelParams = lib.mkMerge [
     (lib.mkBefore [ "quiet" "loglevel=0" ])
-    [ "console=tty0" "console=ttyAMA0,115200" "console=hvc0" ]
+    (if isAarch64
+      then [ "console=tty0" "console=ttyAMA0,115200" "console=hvc0" ]
+      else [ "console=tty0" "console=ttyS0,115200" ])
   ];
   boot.growPartition = true;
 

--- a/scripts/run-vm.sh
+++ b/scripts/run-vm.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Launch a stereOS image in QEMU on Apple Silicon.
+# Launch a stereOS image in QEMU.
 #
 # Supports two boot modes (auto-detected):
 #   1. Direct kernel boot — uses kernel artifacts (bzImage, initrd, cmdline)
@@ -12,15 +12,36 @@
 # writable qcow2 for runtime mutations.
 #
 # Usage:
-#   ./scripts/run-vm.sh [path-to-image] [ssh-port]
+#   ./scripts/run-vm.sh [path-to-image] [ssh-port] [arch]
 #
 # Defaults:
 #   image: ./result/stereos.img (raw) or ./result/stereos.qcow2
 #   port:  2222
+#   arch:  aarch64 (or x86_64)
 #
 # Requires: nix devShell (provides QEMU and STEREOS_EFI_CODE)
 #
 set -euo pipefail
+
+# -- Detect target architecture -----------------------------------------------
+# Auto-detect from environment or use default
+TARGET_ARCH="${STEREOS_TARGET_ARCH:-aarch64}"
+case "$TARGET_ARCH" in
+  aarch64|arm64)
+    QEMU_SYSTEM="qemu-system-aarch64"
+    QEMU_MACHINE="virt,highmem=on"
+    ;;
+  x86_64|x64)
+    TARGET_ARCH="x86_64"
+    QEMU_SYSTEM="qemu-system-x86_64"
+    QEMU_MACHINE="pc,accel=hvf"
+    ;;
+  *)
+    echo "ERROR: Unknown architecture: $TARGET_ARCH"
+    echo "Supported: aarch64, x86_64"
+    exit 1
+    ;;
+esac
 
 # -- Locate image ------------------------------------------------------------
 # Try raw first (canonical format), fall back to qcow2
@@ -34,7 +55,7 @@ else
   echo "ERROR: No image found."
   echo "Build one first:"
   echo "  make build         # → result/stereos.img (raw)"
-  echo "  make build-qcow2   # → result/stereos.qcow2"
+  echo "  make build-qcow2  # → result/stereos.qcow2"
   exit 1
 fi
 
@@ -62,7 +83,7 @@ if [ "$BOOT_MODE" = "efi" ]; then
     echo "Run this script from inside the nix devShell: nix develop"
     echo ""
     echo "Alternatively, build kernel artifacts for direct boot (no EFI needed):"
-    echo "  nix build .#packages.aarch64-linux.<mixtape>-kernel-artifacts --impure -o result-kernel"
+    echo "  nix build .#packages.${TARGET_ARCH}-linux.<mixtape>-kernel-artifacts --impure -o result-kernel"
     exit 1
   fi
   if [ ! -f "$STEREOS_EFI_CODE" ]; then
@@ -133,6 +154,7 @@ fi
 
 echo "══════════════════════════════════════════════════════════"
 echo "  stereOS VM starting"
+echo "  Arch:   $TARGET_ARCH"
 echo "  Boot:   $BOOT_MODE"
 echo "  Image:  $IMAGE"
 if [ "$BOOT_MODE" = "direct-kernel" ]; then
@@ -144,8 +166,8 @@ echo "  Vsock:  $VSOCK_MSG"
 echo "  Quit:   Ctrl-A X"
 echo "══════════════════════════════════════════════════════════"
 
-qemu-system-aarch64 \
-  -machine virt,highmem=on \
+$QEMU_SYSTEM \
+  -machine "$QEMU_MACHINE" \
   -accel hvf \
   -cpu host \
   -m 4G \


### PR DESCRIPTION
* ✨ Adds ` targetSystems = [ "aarch64-linux" "x86_64-linux" ];` to support `x86`. Now, can target `nix build .#packages.x86_64-linux.coder-dist`

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 2 no changes — [View all](https://hub.continue.dev/inbox/pr/papercomputeco/stereOS/23?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->