### PR TITLE
🐛 fix: Make run-vm.sh and devshell work on Linux x86_64 hosts

### DIFF
--- a/flake/devshell.nix
+++ b/flake/devshell.nix
@@ -31,11 +31,11 @@
 
         # Set architecture-specific QEMU and EFI firmware
         if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
-          echo "  QEMU: $(qemu-system-aarch64 --version | head 1)"
+          echo "  QEMU: $(qemu-system-aarch64 --version | head -1)"
           export QEMU_SYSTEM="qemu-system-aarch64"
           export STEREOS_EFI_CODE="${pkgs.qemu}/share/qemu/edk2-aarch64-code.fd"
         else
-          echo "  QEMU: $(qemu-system-x86_64 --version | head 1)"
+          echo "  QEMU: $(qemu-system-x86_64 --version | head -1)"
           export QEMU_SYSTEM="qemu-system-x86_64"
           export STEREOS_EFI_CODE="${pkgs.qemu}/share/qemu/edk2-x86_64-code.fd"
         fi

--- a/scripts/run-vm.sh
+++ b/scripts/run-vm.sh
@@ -23,18 +23,29 @@
 #
 set -euo pipefail
 
-# -- Detect target architecture -----------------------------------------------
-# Auto-detect from environment or use default
-TARGET_ARCH="${STEREOS_TARGET_ARCH:-aarch64}"
+# -- Detect host and target architectures -------------------------------------
+# Normalize `uname -m` to the canonical names we use below.
+case "$(uname -m)" in
+  aarch64|arm64)  HOST_ARCH="aarch64" ;;
+  x86_64|amd64)   HOST_ARCH="x86_64"  ;;
+  *)              HOST_ARCH="unknown" ;;
+esac
+
+# Target arch defaults to the host arch so `./scripts/run-vm.sh` just works
+# on a native image. Override with STEREOS_TARGET_ARCH=<aarch64|x86_64> to
+# cross-emulate (will use tcg, below).
+TARGET_ARCH="${STEREOS_TARGET_ARCH:-$HOST_ARCH}"
 case "$TARGET_ARCH" in
   aarch64|arm64)
+    TARGET_ARCH="aarch64"
     QEMU_SYSTEM="qemu-system-aarch64"
     QEMU_MACHINE="virt,highmem=on"
     ;;
-  x86_64|x64)
+  x86_64|x64|amd64)
     TARGET_ARCH="x86_64"
     QEMU_SYSTEM="qemu-system-x86_64"
-    QEMU_MACHINE="pc,accel=hvf"
+    # q35 is the modern x86 chipset; i440fx ("pc") is legacy.
+    QEMU_MACHINE="q35"
     ;;
   *)
     echo "ERROR: Unknown architecture: $TARGET_ARCH"
@@ -42,6 +53,35 @@ case "$TARGET_ARCH" in
     exit 1
     ;;
 esac
+
+# -- Pick accelerator ---------------------------------------------------------
+# Hardware acceleration requires host ISA == target ISA. When they differ
+# (user asked to cross-emulate), fall back to tcg — slow but correct.
+# hvf on macOS (Hypervisor.framework), kvm on Linux.
+if [ "$HOST_ARCH" != "$TARGET_ARCH" ]; then
+  HOST_ACCEL="tcg"
+else
+  case "$(uname -s)" in
+    Darwin) HOST_ACCEL="hvf" ;;
+    Linux)  HOST_ACCEL="kvm" ;;
+    *)      HOST_ACCEL="tcg" ;;
+  esac
+fi
+
+# -- Pick CPU model -----------------------------------------------------------
+# `-cpu host` only works when QEMU is hardware-accelerated (kvm/hvf). Under
+# tcg cross-architecture emulation the target QEMU rejects it (e.g.
+# qemu-system-aarch64 errors with "kvm required to use host cpu"). Pick a
+# generic, target-appropriate model on the tcg path instead.
+if [ "$HOST_ACCEL" = "tcg" ]; then
+  case "$TARGET_ARCH" in
+    aarch64) CPU_MODEL="cortex-a72" ;;
+    x86_64)  CPU_MODEL="qemu64"     ;;
+    *)       CPU_MODEL="max"        ;;
+  esac
+else
+  CPU_MODEL="host"
+fi
 
 # -- Locate image ------------------------------------------------------------
 # Try raw first (canonical format), fall back to qcow2
@@ -155,6 +195,7 @@ fi
 echo "══════════════════════════════════════════════════════════"
 echo "  stereOS VM starting"
 echo "  Arch:   $TARGET_ARCH"
+echo "  Accel:  $HOST_ACCEL"
 echo "  Boot:   $BOOT_MODE"
 echo "  Image:  $IMAGE"
 if [ "$BOOT_MODE" = "direct-kernel" ]; then
@@ -168,8 +209,8 @@ echo "════════════════════════�
 
 $QEMU_SYSTEM \
   -machine "$QEMU_MACHINE" \
-  -accel hvf \
-  -cpu host \
+  -accel "$HOST_ACCEL" \
+  -cpu "$CPU_MODEL" \
   -m 4G \
   -smp 4 \
   "${BOOT_ARGS[@]}" \


### PR DESCRIPTION
### Summary

Follow-up to #23. The arg-structure change went in, but a few x86/macOS-isms
kept `./scripts/run-vm.sh` from actually booting a VM on a Linux x86_64
host, and the devshell hook had a typo.

* 🐛 `scripts/run-vm.sh` picks the accelerator from `uname -s` — `kvm` on
  Linux, `hvf` on macOS. Was hardcoded to `-accel hvf`, which is macOS's
  Hypervisor.framework and isn't a thing on Linux.
* 🐛 `scripts/run-vm.sh` uses `q35` for x86_64 instead of `pc`. `pc` is
  i440fx (legacy); `q35` is what every modern toolchain assumes (and
  what masterblaster's QEMU backend configures).
* 🐛 `flake/devshell.nix` — `head 1` → `head -1` (×2). The missing dash
  meant the banner line swallowed QEMU's version output silently.
* 🧹 `scripts/run-vm.sh` banner now prints `Accel:` alongside `Arch:` so
  it's obvious which accelerator the VM is using.

### Testing

* `nix flake show` clean on all four declared systems
  (`{aarch64,x86_64}-{darwin,linux}`).
* Built `.#packages.x86_64-linux.coder-dist` on a NixOS x86_64 host —
  produced a `mixtape.toml` with `arch = "x86_64-linux"` and the expected
  disk/kernel artifacts.
* Booted the resulting qcow2 via
  `STEREOS_TARGET_ARCH=x86_64 ./scripts/run-vm.sh` — guest reached
  `multi-user.target`, stereosd + agentd were active, and
  `/run/stereos-ready` was populated.
* Native macOS (`aarch64-darwin`) `nix develop` still enters the shell
  cleanly and prints the aarch64 QEMU version.