### PR TITLE
🔧 fix: bump DAGGER_VERSION 0.20.6 → 0.20.8 in CI workflows

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.20.8"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- The CLI installed by `dagger-for-github` no longer round-trips cleanly with the current daggerverse modules at v0.20.6. The version handshake fails before `dagger call` reaches user code.
- Bumps `DAGGER_VERSION` to 0.20.8 across the workflows, matching the rest of the org repos (e.g. `paper` PR #40) that have already moved.

Refs PCC-543

## Test plan

- [ ] CI / PR / release workflows pass on this PR