### PR TITLE
chore: bump Dagger to 0.21.8

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,9 +8,6 @@ permissions:
   contents: read
   pull-requests: read
 
-env:
-  DAGGER_VERSION: "0.21.8"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -24,14 +21,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.4.1
-        with:
-          version: ${{ env.DAGGER_VERSION }}
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
 
       - name: Check PR title conformance
         run: |
-          dagger call -m github.com/papercomputeco/daggerverse/ghcontrib \
+          nix develop --command dagger call -m github.com/papercomputeco/daggerverse/ghcontrib@45e997aec734ec4875ff57bebed2317e1bd49185 \
               --token=env://GH_TOKEN \
               --repo="${{ github.repository }}" \
             check-pull-request \
@@ -48,14 +46,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.4.1
-        with:
-          version: ${{ env.DAGGER_VERSION }}
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
 
       - name: Check Linear magic word
         run: |
-          dagger call -m github.com/papercomputeco/daggerverse/ghcontrib \
+          nix develop --command dagger call -m github.com/papercomputeco/daggerverse/ghcontrib@45e997aec734ec4875ff57bebed2317e1bd49185 \
               --token=env://GH_TOKEN \
               --repo="${{ github.repository }}" \
             check-pull-request-linear-magic-word \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 
 env:
-  DAGGER_VERSION: "0.20.8"
+  DAGGER_VERSION: "0.21.8"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.2.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           version: ${{ env.DAGGER_VERSION }}
 
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.2.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           version: ${{ env.DAGGER_VERSION }}
 

--- a/dagger.json
+++ b/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "stereOS",
-  "engineVersion": "v0.19.11",
+  "engineVersion": "v0.21.8",
   "sdk": {
     "source": "go"
   },

--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780108791,
-        "narHash": "sha256-S9oJkLiePBqIxzBjfK0qjtCpbXv4sK1laeRrjTucxJs=",
+        "lastModified": 1785344846,
+        "narHash": "sha256-E0v8IiF9sEWNw615Yae1RH8KtMuOOF+mcafu2m0kHyE=",
         "owner": "dagger",
         "repo": "nix",
-        "rev": "9674fc5c98870b7ea103b8fcd4f08bf46b40bbb6",
+        "rev": "b35b2b5ab62ace3a3c1e779c497de1ad762a4aa1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bump Dagger engine to v0.21.8 (latest, 2026-07-29) and dagger/dagger-for-github to v8.4.1.